### PR TITLE
add a todo github action

### DIFF
--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -1,0 +1,17 @@
+name: todo2issue
+on: ["push"]
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@master"
+      - name: "TODO to Issue"
+        uses: "alstr/todo-to-issue-action@v2.0"
+        with:
+          REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: "# TODO"
+          COMMENT_MARKER: "#"
+        id: "todo"


### PR DESCRIPTION
Adds a GitHub action which turns any text in the repo (markdown, code) prefixed with `# TODO` into a new GitHub issue with a `todo` label


This might be useful for:
- keeping track of todos for this lesson 
- also allowing us to discuss specific todos under a new issue 
