### PR TITLE
Added a small intro to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,16 @@
 
 [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
 
-**Thanks for contributing to The Carpentries Incubator!**
-This repository provides a blank starting point for lessons to be developed here.
+Our aim with this lesson is to empower GLAM ([Galleries, Libraries, Archives, and Museums](https://en.wikipedia.org/wiki/GLAM_(industry))) staff with the foundation to support, participate in and begin to undertake in their own right, machine learning based research and projects with heritage collections. 
 
-A member of the [Carpentries Curriculum Team](https://carpentries.org/team/)
-will work with you to get your lesson listed on the
-[Community Developed Lessons page][community-lessons]
-and make sure you have everything you need to begin developing your new lesson.
-
-## What to do next
-
-Before you begin developing your new lesson,
-here are a few things we recommend you do:
-
-* [ ] Decide on a title for your new lesson!
-  Once you've chosen a new title, you can set the value for `lesson_title`
-  in [`_config.yml`](_config.yml)
-* [ ] Add the URL to your built lesson pages to the repository description\*
-* [ ] Fill in the fields marked `# TODO` in:
-  * this README
-  * [`_config.yml`](_config.yml)
-* [ ] If you're going to be developing lesson material for the first time
-  according to our design principles,
-  consider reading the [Carpentries Curriculum Development Handbook][cdh]
-* [ ] Consult the [Lesson Example][lesson-example] website to find out more about
-  working with the lesson template
-* [ ] If you are planning to write your lesson in RMarkdown,
-  [create a `main` branch and set this as the default branch in your repository settings][change-default-branch]
-* [ ] Update this README with relevant information about your lesson
-  and delete this section
-
-
-\* To set the URL on GitHub, click the gear wheel button next to **About**
-on the right of the repository landing page.
-The lesson URL structure is **https://carpentries-incubator.github.io/<repository-slug\>**:
-a repository at https://github.com/carpentries-incubator/new-lesson/ will have pages at
-the lesson URL https://carpentries-incubator.github.io/new-lesson/.
-
+After following this lesson, learners will be able to:
+* Explain and differentiate key terms, phrases, and concepts associated with AI and Machine Learning in GLAM
+* Describe ways in which AI is being innovatively used in the cultural heritage context today
+* Identify what kinds of tasks machine learning models excel at in GLAM applications
+* Identify weaknesses in machine learning models   
+* Reflect on ethical implications of applying machine learning to cultural heritage collections and discuss potential mitigation strategies
+* Summarise the practical, technical steps involved in undertaking machine learning projects
+* Identify additional resources on AI and Machine Learning in GLAM
 
 ## Contributing
 


### PR DESCRIPTION
I added a small introduction from our Lesson Aims document. Going forward, we should probably mirror the intro text from index.md.

I also removed a lot of the boilerplate instructions on how to set up the page (which we've done)

