### PR TITLE
update contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ and to meet some of our community members.
 ## Where to Contribute
 
 1.  If you wish to change this lesson,
-    please work in <https://github.com/swcarpentry/FIXME>,
-    which can be viewed at <https://swcarpentry.github.io/FIXME>.
+    please work in <https://github.com/carpentries-incubator/machine-learning-librarians-archivists>,
+    which can be viewed at <https://carpentries-incubator.github.io/machine-learning-librarians-archivists/>.
 
 2.  If you wish to change the example lesson,
     please work in <https://github.com/carpentries/lesson-example>,
@@ -130,7 +130,7 @@ repository for reference while revising.
 
 General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
 happens on the [discussion mailing list][discuss-list],
-which everyone is welcome to join.
+which everyone is welcome to join. You can also join the [Carpentries Slack channel](https://carpentries.slack.com/), which includes channels for #libraries and #lc-ai-glam. 
 You can also [reach us by email][email].
 
 [email]: mailto:admin@software-carpentry.org

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTR
 the [more detailed guidelines][lesson-example] on proper formatting, ways to render the lesson locally, and even
 how to write new episodes.
 
-Please see the current list of [issues][# TODO] for ideas for contributing to this
+Please see the current list of [issues](https://github.com/carpentries-incubator/machine-learning-librarians-archivists/issues) for ideas for contributing to this
 repository. For making your contribution, we use the GitHub flow, which is
 nicely explained in the chapter [Contributing to a Project](http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) in Pro Git
 by Scott Chacon.


### PR DESCRIPTION
Fixes #70 
Note that CONTRIBUTING.md currently links to carpentries-incubator repo and should be updated when the lesson moves to [LibraryCarpentry](https://github.com/LibraryCarpentry/).